### PR TITLE
bind to X instead of P

### DIFF
--- a/scripts/modkit/keybinds.lua
+++ b/scripts/modkit/keybinds.lua
@@ -1,7 +1,7 @@
 if (MODKIT_KEYBINDS == nil) then
     MK_KeyFunctions = {
         showConsoleScreen = {
-            key = PKEY,
+            key = XKEY,
             fn = function ()
                 if (modkit == nil or modkit.console == nil) then
                     dofilepath("data:scripts/modkit/console.lua");


### PR DESCRIPTION
Seems like nothing is bound to X - some legacy stuff about sending stop commands? Does nothing and presumably deprecated for 'S' key bind